### PR TITLE
Added bindings for the variance modelling code.

### DIFF
--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(
     src/per_cell_qc_metrics.cpp
     src/per_cell_qc_filters.cpp
     src/filter_cells.cpp
+    src/model_gene_var.cpp
     src/run_pca.cpp
     src/NumericMatrix.cpp
 )

--- a/wasm/src/model_gene_var.cpp
+++ b/wasm/src/model_gene_var.cpp
@@ -1,0 +1,75 @@
+#include <emscripten/bind.h>
+
+#include "NumericMatrix.h"
+#include "utils.h"
+
+#include "scran/feature_selection/ModelGeneVar.hpp"
+
+#include <vector>
+#include <algorithm>
+#include <cstdint>
+
+/**
+ * Model the variance of the log-expression values for each gene, accounting for the mean-variance trend.
+ *
+ * @param mat An input log-expression matrix containing features in rows and cells in columns.
+ * @param span The span of the LOWESS smoother for fitting the mean-variance trend.
+ *
+ * @param use_blocks Whether or not to compute the statistics within each block.
+ * @param blocks If `use_blocks = true`, offset to an array of `int32_t`s with `ncells` elements, containing the block assignment for each cell.
+ * Block IDs should be consecutive and 0-based.
+ * If `use_blocks = false`, this value is ignored.
+ *
+ * @param[out] means Offset to an array of offsets of length equal to the number of blocks (or 1, if `use_blocks = false`).
+ * Each internal offset points to an output buffer of `double`s with `mat.nrow()` elements, to hold the mean of each feature in each block.
+ * @param[out] variances Offset to an array of offsets of length equal to the number of blocks (or 1, if `use_blocks = false`).
+ * Each internal offset points to an output buffer of `double`s with `mat.nrow()` elements, to hold the variance of each feature in each block.
+ * @param[out] fitted Offset to an array of offsets of length equal to the number of blocks (or 1, if `use_blocks = false`).
+ * Each internal offset points to an output buffer of `double`s with `mat.nrow()` elements, to hold the fitted value of the trend for each feature in each block.
+ * @param[out] residuals Offset to an array of offsets of length equal to the number of blocks (or 1, if `use_blocks = false`).
+ * Each internal offset points to an output buffer of `double`s with `mat.nrow()` elements, to hold the residual from the trend for each feature in each block.
+ *
+ * @return The buffers in `means`, `variances`, `fitted` and `residuals` are filled.
+ * If `use_block = true`, statistics are computed separately for the cells in each block.
+ */
+void model_gene_var(const NumericMatrix& mat,
+
+                         bool use_blocks, 
+                         uintptr_t blocks,
+                         double span, 
+
+                         uintptr_t means,
+                         uintptr_t variances,
+                         uintptr_t fitted,
+                         uintptr_t residuals
+                         ) 
+{
+    scran::ModelGeneVar var;
+    var.set_span(span);
+    int nblocks = 1;
+    if (use_blocks) {
+        const int32_t* bptr = reinterpret_cast<const int32_t*>(blocks);
+        var.set_blocks(mat.ncol(), bptr);
+        nblocks = *std::max_element(bptr, bptr + mat.ncol()) + 1;
+    }
+
+    var.run(mat.ptr.get(),
+        cast_vector_of_pointers<double*>(means, nblocks),
+        cast_vector_of_pointers<double*>(variances, nblocks),
+        cast_vector_of_pointers<double*>(fitted, nblocks),
+        cast_vector_of_pointers<double*>(residuals, nblocks)
+    );
+
+    return;
+}
+
+/**
+ * @cond 
+ */
+EMSCRIPTEN_BINDINGS(model_gene_var) {
+    emscripten::function("model_gene_var", &model_gene_var);
+}
+/**
+ * @endcond 
+ */
+

--- a/wasm/src/model_gene_var.cpp
+++ b/wasm/src/model_gene_var.cpp
@@ -46,10 +46,10 @@ void model_gene_var(const NumericMatrix& mat,
 {
     scran::ModelGeneVar var;
     var.set_span(span);
+    auto bptr = add_blocks(var, use_blocks, blocks, mat.ncol());
+
     int nblocks = 1;
     if (use_blocks) {
-        const int32_t* bptr = reinterpret_cast<const int32_t*>(blocks);
-        var.set_blocks(mat.ncol(), bptr);
         nblocks = *std::max_element(bptr, bptr + mat.ncol()) + 1;
     }
 


### PR DESCRIPTION
```js
          var means = allocate_double_vector(nrow);
          var means_array = allocate_uint32_vector(1);
          means_array.vector[0] = means.offset;

          var vars = allocate_double_vector(nrow);
          var vars_array = allocate_uint32_vector(1);
          vars_array.vector[0] = vars.offset;

          var fitted = allocate_double_vector(nrow);
          var fitted_array = allocate_uint32_vector(1);
          fitted_array.vector[0] = fitted.offset;

          var resids = allocate_double_vector(nrow);
          var resids_array = allocate_uint32_vector(1);
          resids_array.vector[0] = resids.offset;

          Module.model_gene_var(instance, false, 0, 0.3, means_array.offset, vars_array.offset, fitted_array.offset, resids_array.offset);
```