### PR TITLE
Throw actual Error objects rather than strings.

### DIFF
--- a/js/cbind.js
+++ b/js/cbind.js
@@ -63,14 +63,14 @@ export function cbindWithNames(x, names) {
     try {
         // Building a common set of rownames.
         if (names.length !== x.length) {
-            throw "length of 'names' should be equal to length of 'x'";
+            throw new Error("length of 'names' should be equal to length of 'x'");
         }
 
         let common = {};
         let universe = [];
         for (var i = 0; i < names.length; i++) {
             if (x[i].numberOfRows() !== names[i].length) {
-                throw "length of each 'names' must equal number of rows of its corresponding 'x'";
+                throw new Error("length of each 'names' must equal number of rows of its corresponding 'x'");
             }
             names[i].forEach(x => {
                 if (!(x in common)) {

--- a/js/clusterKmeans.js
+++ b/js/clusterKmeans.js
@@ -134,7 +134,7 @@ export function clusterKmeans(x, clusters, { numberOfDims = null, numberOfCells 
     const init_choices = ["random", "kmeans++", "pca-part"]
     let init_chosen = init_choices.indexOf(initMethod);
     if (init_chosen == -1) {
-        throw "'initMethod' should be one of 'random', 'kmeans++' or 'pca-part'";
+        throw new Error("'initMethod' should be one of 'random', 'kmeans++' or 'pca-part'");
     }
 
     try {
@@ -148,12 +148,12 @@ export function clusterKmeans(x, clusters, { numberOfDims = null, numberOfCells 
 
         } else {
             if (numberOfDims === null || numberOfCells === null) {
-                throw "'numberOfDims' and 'numberOfCells' must be specified when 'x' is an Array";
+                throw new Error("'numberOfDims' and 'numberOfCells' must be specified when 'x' is an Array");
             }
 
             buffer = utils.wasmifyArray(x, "Float64WasmArray");
             if (buffer.length != numberOfDims * numberOfCells) {
-                throw "length of 'x' must be the product of 'numberOfDims' and 'numberOfCells'";
+                throw new Error("length of 'x' must be the product of 'numberOfDims' and 'numberOfCells'");
             }
 
             pptr = buffer.offset;

--- a/js/computePerCellQCFilters.js
+++ b/js/computePerCellQCFilters.js
@@ -139,7 +139,7 @@ export function computePerCellQCFilters(metrics, { numberOfMADs = 3, block = nul
         if (block !== null) {
             block_data = utils.wasmifyArray(block, "Int32WasmArray");
             if (block_data.length != metrics.sums().length) {
-                throw "'block' must be of length equal to the number of cells in 'metrics'";
+                throw new Error("'block' must be of length equal to the number of cells in 'metrics'");
             }
             use_blocks = true;
             bptr = block_data.offset;

--- a/js/computePerCellQCMetrics.js
+++ b/js/computePerCellQCMetrics.js
@@ -94,7 +94,7 @@ export function computePerCellQCMetrics(x, subsets) {
         if (subsets instanceof wa.Uint8WasmArray) {
             let nsubsets = Math.round(subsets.length / x.numberOfRows());
             if (nsubsets * x.numberOfRows() != subsets.length) {
-                throw "length of 'subsets' should be a multiple of the matrix rows";
+                throw new Error("length of 'subsets' should be a multiple of the matrix rows");
             }
 
             // This will either create a cheap view, or it'll clone
@@ -114,7 +114,7 @@ export function computePerCellQCMetrics(x, subsets) {
                 for (var i = 0; i < subsets.length; i++) {
                     let current = subsets[i];
                     if (current.length != x.numberOfRows()) {
-                        throw "length of each array in 'subsets' should be equal to the matrix rows";
+                        throw new Error("length of each array in 'subsets' should be equal to the matrix rows");
                     }
                     tmp.array().set(current, offset);
                     offset += current.length;
@@ -128,7 +128,7 @@ export function computePerCellQCMetrics(x, subsets) {
             raw = wasm.call(module => module.per_cell_qc_metrics(x.matrix, 0, 0));
 
         } else {
-            throw "'subsets' should be an Array or Uint8WasmArray";
+            throw new Error("'subsets' should be an Array or Uint8WasmArray");
         }
 
         output = new PerCellQCMetrics(raw);

--- a/js/filterCells.js
+++ b/js/filterCells.js
@@ -26,7 +26,7 @@ export function filterCells(x, filters) {
         } else {
             filter_data = utils.wasmifyArray(filters, "Uint8WasmArray");
             if (filter_data.length != x.numberOfColumns()) {
-                throw "length of 'filters' must be equal to number of columns in 'x'";
+                throw new Error("length of 'filters' must be equal to number of columns in 'x'");
             }
             ptr = filter_data.offset;
         }

--- a/js/findNearestNeighbors.js
+++ b/js/findNearestNeighbors.js
@@ -68,12 +68,12 @@ export function buildNeighborSearchIndex(x, { numberOfDims = null, numberOfCells
 
         } else {
             if (numberOfDims === null || numberOfCells === null) {
-                throw "'numberOfDims' and 'numberOfCells' must be specified when 'x' is an Array";
+                throw new Error("'numberOfDims' and 'numberOfCells' must be specified when 'x' is an Array");
             }
 
             buffer = utils.wasmifyArray(x, "Float64WasmArray");
             if (buffer.length != numberOfDims * numberOfCells) {
-                throw "length of 'x' must be the product of 'numberOfDims' and 'numberOfCells'";
+                throw new Error("length of 'x' must be the product of 'numberOfDims' and 'numberOfCells'");
             }
 
             pptr = buffer.offset;
@@ -140,7 +140,7 @@ export class NeighborSearchResults {
     serialize({ runs = null, indices = null, distances = null } = {}) {
         var copy = (runs === null) + (indices === null) + (distances === null);
         if (copy != 3 && copy != 0) {
-            throw "either all or none of 'runs', 'indices' and 'distances' can be 'null'";
+            throw new Error("either all or none of 'runs', 'indices' and 'distances' can be 'null'");
         }
 
         if (copy === 3) {

--- a/js/hdf5.js
+++ b/js/hdf5.js
@@ -53,12 +53,12 @@ function check_shape(x, shape) {
     if (shape.length > 0) {
         let full_length = shape.reduce((a, b) => a * b);
         if (x.length != full_length) {
-            throw "length of 'x' must be equal to the product of 'shape'";
+            throw new Error("length of 'x' must be equal to the product of 'shape'");
         }
     } else {
         if (x instanceof Array || ArrayBuffer.isView(x)) {
             if (x.length != 1) {
-                throw "length of 'x' should be 1 for a scalar dataset";
+                throw new Error("length of 'x' should be 1 for a scalar dataset");
             }
         } else {
             x = [x];
@@ -170,10 +170,10 @@ export class H5Group extends H5Base {
             } else if (this.#children[name] == "DataSet") {
                 return new H5DataSet(this.file, new_name, options); 
             } else {
-                throw "don't know how to open '" + name + "'";
+                throw new Error("don't know how to open '" + name + "'");
             }
         } else {
-            throw "no '" + name + "' child in this HDF5 Group";
+            throw new Error("no '" + name + "' child in this HDF5 Group");
         }
     }
 
@@ -221,7 +221,7 @@ export class H5Group extends H5Base {
             if (chunks !== null) {
                 chunk_arr = utils.wasmifyArray(chunks, "Int32WasmArray");
                 if (chunk_arr.length != shape_arr.length) {
-                    throw "'chunks' and 'shape' should have the same dimensions";
+                    throw new Error("'chunks' and 'shape' should have the same dimensions");
                 }
                 chunk_offset = chunk_arr.offset;
             }
@@ -343,7 +343,7 @@ export class H5DataSet extends H5Base {
         try {
             type = x.type();
             if (type == "other") {
-                throw "cannot load dataset for an unsupported type";
+                throw new Error("cannot load dataset for an unsupported type");
             }
 
             if (type == "String") {

--- a/js/initializeSparseMatrix.js
+++ b/js/initializeSparseMatrix.js
@@ -20,7 +20,7 @@ export function initializeSparseMatrixFromDenseArray(numberOfRows, numberOfColum
     try {
         val_data = utils.wasmifyArray(values, null);
         if (val_data.length !== numberOfRows * numberOfColumns) {
-            throw "length of 'values' is not consistent with supplied dimensions";
+            throw new Error("length of 'values' is not consistent with supplied dimensions");
         }
 
         raw = wasm.call(module => 
@@ -74,10 +74,10 @@ export function initializeSparseMatrixFromCompressedVectors(numberOfRows, number
         ind_data = utils.wasmifyArray(indices, null);
         indp_data = utils.wasmifyArray(pointers, null);
         if (val_data.length != ind_data.length) {
-            throw "'values' and 'indices' should have the same length";
+            throw new Error("'values' and 'indices' should have the same length");
         }
         if (indp_data.length != (byColumn ? numberOfColumns : numberOfRows) + 1) {
-            throw "'pointers' does not have an appropriate length";
+            throw new Error("'pointers' does not have an appropriate length");
         }
 
         raw = wasm.call(module => 

--- a/js/labelCells.js
+++ b/js/labelCells.js
@@ -192,7 +192,7 @@ export function buildLabelledReference(features, loaded, referenceFeatures, { to
         mat_id_buffer = utils.createInt32WasmArray(nfeat);
         ref_id_buffer = utils.createInt32WasmArray(loaded.numberOfFeatures());
         if (referenceFeatures.length != ref_id_buffer.length) {
-            throw "length of 'referenceFeatures' should be equal to the number of features in 'reference'";
+            throw new Error("length of 'referenceFeatures' should be equal to the number of features in 'reference'");
         }
 
         let available = create_feature_availability(features, mat_id_buffer);
@@ -227,7 +227,7 @@ function label_cells(x, expectedNumberOfFeatures, buffer, numberOfFeatures, numb
             target = x.matrix;
         } else if (x instanceof wa.Float64WasmArray) {
             if (x.length !== numberOfFeatures * numberOfCells) {
-                throw "length of 'x' must be equal to the product of 'numberOfFeatures' and 'numberOfCells'";
+                throw new Error("length of 'x' must be equal to the product of 'numberOfFeatures' and 'numberOfCells'");
             }
 
             // This will either create a cheap view, or it'll clone
@@ -236,11 +236,11 @@ function label_cells(x, expectedNumberOfFeatures, buffer, numberOfFeatures, numb
             tempmat = wasm.call(module => module.initialize_dense_matrix(numberOfFeatures, numberOfCells, matbuf.offset, "Float64Array"));
             target = tempmat;
         } else {
-            throw "unknown type for 'x'";
+            throw new Error("unknown type for 'x'");
         }
 
         if (target.nrow() != expectedNumberOfFeatures) {
-            throw "number of rows in 'x' should be equal to length of 'features' used to build '" + msg + "'";
+            throw new Error("number of rows in 'x' should be equal to length of 'features' used to build '" + msg + "'");
         }
 
         let ptr;
@@ -348,14 +348,14 @@ export function integrateLabelledReferences(features, loaded, referenceFeatures,
     // Checking the inputs.
     let nrefs = loaded.length;
     if (referenceFeatures.length != nrefs) {
-        throw "'loaded' and 'referenceFeatures' should be of the same length";
+        throw new Error("'loaded' and 'referenceFeatures' should be of the same length");
     }
     if (built.length != nrefs) {
-        throw "'loaded' and 'built' should be of the same length";
+        throw new Error("'loaded' and 'built' should be of the same length");
     }
     for (var i = 0; i < nrefs; i++) {
         if (loaded[i].numberOfFeatures() != referenceFeatures[i].length) {
-            throw "length of each 'referenceFeatures' should be equal to the number of features in the corresponding 'loaded'";
+            throw new Error("length of each 'referenceFeatures' should be equal to the number of features in the corresponding 'loaded'");
         }
     }
 
@@ -442,7 +442,7 @@ export function integrateLabelledReferences(features, loaded, referenceFeatures,
 export function integrateCellLabels(x, assigned, integrated, { buffer = null, numberOfFeatures = null, numberOfCells = null, quantile = 0.8 } = {}) { 
     let nrefs = integrated.numberOfReferences();
     if (assigned.length != nrefs) {
-        throw "length of 'assigned' should be equal to the number of references in 'integrated'";
+        throw new Error("length of 'assigned' should be equal to the number of references in 'integrated'");
     }
 
     let output;
@@ -464,7 +464,7 @@ export function integrateCellLabels(x, assigned, integrated, { buffer = null, nu
                 fail = true;
             }
             if (fail) {
-                throw "length of each element 'assigned' should be equal to number of columns in 'x'";
+                throw new Error("length of each element 'assigned' should be equal to number of columns in 'x'");
             }
 
             assigned_arrs[i] = utils.wasmifyArray(current, "Int32WasmArray");

--- a/js/logNormCounts.js
+++ b/js/logNormCounts.js
@@ -29,7 +29,7 @@ export function logNormCounts(x, { sizeFactors = null, block = null } = {}) {
         if (sizeFactors !== null) {
             sf_data = utils.wasmifyArray(sizeFactors, "Float64WasmArray");
             if (sf_data.length != x.numberOfColumns()) {
-                throw "length of 'sizeFactors' must be equal to number of columns in 'x'";
+                throw new Error("length of 'sizeFactors' must be equal to number of columns in 'x'");
             }
             sfptr = sf_data.offset;
             use_sf = true;
@@ -41,7 +41,7 @@ export function logNormCounts(x, { sizeFactors = null, block = null } = {}) {
         if (block !== null) {
             block_data = utils.wasmifyArray(block, "Int32WasmArray");
             if (block_data.length != x.numberOfColumns()) {
-                throw "'block' must be of length equal to the number of columns in 'x'";
+                throw new Error("'block' must be of length equal to the number of columns in 'x'");
             }
             use_blocks = true;
             bptr = block_data.offset;

--- a/js/mnnCorrect.js
+++ b/js/mnnCorrect.js
@@ -54,7 +54,7 @@ export function mnnCorrect(x, block, {
             x = x.principalComponents({ copy: "view" });
         } else {
             if (numberOfDims === null || numberOfCells === null || numberOfDims * numberOfCells !== x.length) {
-                throw "length of 'x' must be equal to the product of 'numberOfDims' and 'numberOfCells'";
+                throw new Error("length of 'x' must be equal to the product of 'numberOfDims' and 'numberOfCells'");
             }
             x_data = utils.wasmifyArray(x, "Float64WasmArray");
             x = x_data;
@@ -66,7 +66,7 @@ export function mnnCorrect(x, block, {
 
         block_data = utils.wasmifyArray(block, "Int32WasmArray");
         if (block_data.length != numberOfCells) {
-            throw "'block' must be of length equal to the number of cells in 'x'";
+            throw new Error("'block' must be of length equal to the number of cells in 'x'");
         }
 
         wasm.call(module => module.mnn_correct(

--- a/js/modelGeneVar.js
+++ b/js/modelGeneVar.js
@@ -124,7 +124,7 @@ export function modelGeneVar(x, { block = null, span = 0.3 } = {}) {
         if (block !== null) {
             block_data = utils.wasmifyArray(block, "Int32WasmArray");
             if (block_data.length != x.numberOfColumns()) {
-                throw "'block' must be of length equal to the number of columns in 'x'";
+                throw new Error("'block' must be of length equal to the number of columns in 'x'");
             }
             use_blocks = true;
             bptr = block_data.offset;

--- a/js/permute.js
+++ b/js/permute.js
@@ -84,13 +84,13 @@ export function updatePermutation(x, old) {
     if (x instanceof ScranMatrix) {
         if (x.isPermuted()) {
             if (old.length != x.numberOfRows()) {
-                throw "number of rows in 'x' should be the same as length of 'old'";
+                throw new Error("number of rows in 'x' should be the same as length of 'old'");
             }
             spawnPerm = () => x.permutation({ copy: false });
         }
     } else {
         if (old.length != x.length) {
-            throw "length of 'x' should be the same as length of 'old'";
+            throw new Error("length of 'x' should be the same as length of 'old'");
         }
         spawnPerm = () => x;
     }

--- a/js/runPCA.js
+++ b/js/runPCA.js
@@ -110,7 +110,7 @@ export function runPCA(x, { features = null, numberOfPCs = 25, scale = false, bl
         if (features !== null) {
             feat_data = utils.wasmifyArray(features, "Uint8WasmArray");
             if (feat_data.length != x.numberOfRows()) {
-                throw "length of 'features' should be equal to number of rows in 'x'";
+                throw new Error("length of 'features' should be equal to number of rows in 'x'");
             }
             use_feat = true;
             fptr = feat_data.offset;
@@ -121,7 +121,7 @@ export function runPCA(x, { features = null, numberOfPCs = 25, scale = false, bl
         } else {
             block_data = utils.wasmifyArray(block, "Int32WasmArray");
             if (block_data.length != x.numberOfColumns()) {
-                throw "length of 'block' should be equal to the number of columns in 'x'";
+                throw new Error("length of 'block' should be equal to the number of columns in 'x'");
             }
             if (blockMethod == "block") {
                 raw = wasm.call(module => module.run_blocked_pca(x.matrix, numberOfPCs, use_feat, fptr, scale, block_data.offset));

--- a/js/runTSNE.js
+++ b/js/runTSNE.js
@@ -104,7 +104,7 @@ export function initializeTSNE(x, { perplexity = 30, checkMismatch = true } = {}
             if (checkMismatch) {
                 let k = perplexityToNeighbors(perplexity);
                 if (k * x.numberOfCells() != x.size()) {
-                    throw "number of neighbors in 'x' does not match '3 * perplexity'";
+                    throw new Error("number of neighbors in 'x' does not match '3 * perplexity'");
                 }
             }
             neighbors = x;

--- a/js/scoreMarkers.js
+++ b/js/scoreMarkers.js
@@ -164,7 +164,7 @@ export function scoreMarkers(x, groups, { block = null } = {}) {
     try {
         group_data = utils.wasmifyArray(groups, "Int32WasmArray");
         if (group_data.length != x.numberOfColumns()) {
-            throw "length of 'groups' should be equal to number of columns in 'x'";
+            throw new Error("length of 'groups' should be equal to number of columns in 'x'");
         }
 
         var bptr = 0;
@@ -172,7 +172,7 @@ export function scoreMarkers(x, groups, { block = null } = {}) {
         if (block !== null) {
             block_data = utils.wasmifyArray(block, "Int32WasmArray");
             if (block_data.length != x.numberOfColumns()) {
-                throw "'block' must be of length equal to the number of columns in 'x'";
+                throw new Error("'block' must be of length equal to the number of columns in 'x'");
             }
             use_blocks = true;
             bptr = block_data.offset;

--- a/js/utils.js
+++ b/js/utils.js
@@ -48,7 +48,7 @@ export function createFloat64WasmArray(length) {
 export function wasmifyArray(x, expected) {
     if (x instanceof wa.WasmArray) {
         if (expected !== null && expected != x.constructor.className) {
-            throw "expected '" + expected + "', got '" + x.constructor.className + "'";
+            throw new Error("expected '" + expected + "', got '" + x.constructor.className + "'");
         }
 
         if (x.space === wasmArraySpace()) {
@@ -101,7 +101,7 @@ export function extractXY(ncells, coordinates) {
 export function possibleCopy(x, copy) {
     if (copy === "view") {
         if (x.buffer !== buffer()) {
-            throw "cannot use copy = \"view\" for non-Wasm TypedArrays";
+            throw new Error("cannot use copy = \"view\" for non-Wasm TypedArrays");
         }
 
         let view_class = x.constructor.name.replace("Array", "WasmArray");

--- a/js/wasm.js
+++ b/js/wasm.js
@@ -35,7 +35,7 @@ export async function initialize({ numberOfThreads = 4, localFile = false } = {}
 
 export function call(func) {
     if (! ("module" in cache)) {
-        throw "Wasm module needs to be initialized via 'initialize()'";
+        throw new Error("Wasm module needs to be initialized via 'initialize()'");
     }
 
     var output;
@@ -43,7 +43,7 @@ export function call(func) {
         output = func(cache.module);    
     } catch (e) {
         if (typeof e == "number") {
-            throw cache.module.get_error_message(e);
+            throw new Error(cache.module.get_error_message(e));
         } else {
             throw e;
         }
@@ -53,7 +53,7 @@ export function call(func) {
 
 export function buffer() {
     if (! ("module" in cache)) {
-        throw "Wasm module needs to be initialized via 'initialize()'";
+        throw new Error("Wasm module needs to be initialized via 'initialize()'");
     }
     return cache.module.wasmMemory.buffer;
 }


### PR DESCRIPTION
This should hopefully preserve the stacktrace and make debugging easier.