### PR TITLE
Enable direct loading of sparse matrices without reorganization.

### DIFF
--- a/js/initializeSparseMatrix.js
+++ b/js/initializeSparseMatrix.js
@@ -10,10 +10,16 @@ import { ScranMatrix } from "./ScranMatrix.js";
  * @param {number} numberOfColumns Number of columns in the matrix.
  * @param {WasmArray|Array|TypedArray} values Values of all elements in the matrix, stored in column-major order.
  * These should all be non-negative integers, even if they are stored in floating-point.
+ * @param {object} [options] - Optional parameters.
+ * @param {boolean} [options.layered=true] - Whether to create a layered sparse matrix, which reorders the rows of the loaded matrix for better memory efficiency.
+ * If `true`, the identity of the rows in the output matrix can be determined from {@linkcode ScranMatrix#identities ScranMatrix.identities}.
  *
- * @return {ScranMatrix} A layered sparse matrix.
+ * @return {ScranMatrix} 
+ * If `layered = false`, a sparse matrix is returned with no reorganization of the rows.
+ *
+ * If `layered = true`, a layered sparse matrix is returned where rows are shuffled to enable use of smaller integer types for low-abundance genes.
  */
-export function initializeSparseMatrixFromDenseArray(numberOfRows, numberOfColumns, values) {
+export function initializeSparseMatrixFromDenseArray(numberOfRows, numberOfColumns, values, { layered = true } = {}) {
     var val_data; 
     var output;
 
@@ -28,7 +34,8 @@ export function initializeSparseMatrixFromDenseArray(numberOfRows, numberOfColum
                 numberOfRows, 
                 numberOfColumns, 
                 val_data.offset, 
-                val_data.constructor.className.replace("Wasm", "")
+                val_data.constructor.className.replace("Wasm", ""),
+                layered
             ),
             ScranMatrix
         );
@@ -58,10 +65,15 @@ export function initializeSparseMatrixFromDenseArray(numberOfRows, numberOfColum
  * @param {object} [options] - Optional parameters.
  * @param {boolean} [options.byColumn=true] - Whether the supplied arrays refer to the compressed sparse column format.
  * If `true`, `indices` should contain column indices and `pointers` should specify the start of each row in `indices`.
+ * @param {boolean} [options.layered=true] - Whether to create a layered sparse matrix, which reorders the rows of the loaded matrix for better memory efficiency.
+ * If `true`, the identity of the rows in the output matrix can be determined from {@linkcode ScranMatrix#identities ScranMatrix.identities}.
  *
- * @return {ScranMatrix} A layered sparse matrix.
+ * @return {ScranMatrix} 
+ * If `layered = false`, a sparse matrix is returned with no reorganization of the rows.
+ *
+ * If `layered = true`, a layered sparse matrix is returned where rows are shuffled to enable use of smaller integer types for low-abundance genes.
  */ 
-export function initializeSparseMatrixFromCompressedVectors(numberOfRows, numberOfColumns, values, indices, pointers, { byColumn = true } = {}) {
+export function initializeSparseMatrixFromCompressedVectors(numberOfRows, numberOfColumns, values, indices, pointers, { byColumn = true, layered = true } = {}) {
     var val_data;
     var ind_data;
     var indp_data;
@@ -89,7 +101,8 @@ export function initializeSparseMatrixFromCompressedVectors(numberOfRows, number
                 ind_data.constructor.className.replace("Wasm", ""), 
                 indp_data.offset, 
                 indp_data.constructor.className.replace("Wasm", ""), 
-                byColumn 
+                byColumn,
+                layered
             ),
             ScranMatrix
         );

--- a/js/initializeSparseMatrix.js
+++ b/js/initializeSparseMatrix.js
@@ -116,12 +116,17 @@ export function initializeSparseMatrixFromCompressedVectors(numberOfRows, number
  * Alternatively, this can be a string containing a file path to a MatrixMarket file.
  * On browsers, this should be a path in the virtual filesystem, typically created with {@linkcode writeFile}. 
  * @param {object} [options] - Optional parameters.
- * @param {boolean} [options.compressed=null] - Whether the buffer is Gzip-compressed.
+ * @param {?boolean} [options.compressed=null] - Whether the buffer is Gzip-compressed.
  * If `null`, we detect this automatically from the magic number in the header.
+ * @param {boolean} [options.layered=true] - Whether to create a layered sparse matrix, which reorders the rows of the loaded matrix for better memory efficiency.
+ * If `true`, the identity of the rows in the output matrix can be determined from {@linkcode ScranMatrix#identities ScranMatrix.identities}.
  *
- * @return {ScranMatrix} A layered sparse matrix.
+ * @return {ScranMatrix} 
+ * If `layered = false`, a sparse matrix is returned with no reorganization of the rows.
+ *
+ * If `layered = true`, a layered sparse matrix is returned where rows are shuffled to enable use of smaller integer types for low-abundance genes.
  */
-export function initializeSparseMatrixFromMatrixMarket(x, { compressed = null } = {}) {
+export function initializeSparseMatrixFromMatrixMarket(x, { compressed = null, layered = true } = {}) {
     var buf_data;
     var output;
 
@@ -130,12 +135,12 @@ export function initializeSparseMatrixFromMatrixMarket(x, { compressed = null } 
         if (typeof x !== "string") {
             buf_data = utils.wasmifyArray(x, "Uint8WasmArray");
             output = gc.call(
-                module => module.read_matrix_market_from_buffer(buf_data.offset, buf_data.length, compressed),
+                module => module.read_matrix_market_from_buffer(buf_data.offset, buf_data.length, compressed, layered),
                 ScranMatrix
             );
         } else {
             output = gc.call(
-                module => module.read_matrix_market_from_file(x, compressed),
+                module => module.read_matrix_market_from_file(x, compressed, layered),
                 ScranMatrix
             );
         }
@@ -215,12 +220,18 @@ export function extractMatrixMarketDimensions(x, { compressed = null } = {}) {
  * @param {string} name Name of the dataset inside the file.
  * This can be a HDF5 Dataset for dense matrices or a HDF5 Group for sparse matrices.
  * For the latter, both H5AD and 10X-style sparse formats are supported.
+ * @param {object} [options] - Optional parameters.
+ * @param {boolean} [options.layered=true] - Whether to create a layered sparse matrix, which reorders the rows of the loaded matrix for better memory efficiency.
+ * If `true`, the identity of the rows in the output matrix can be determined from {@linkcode ScranMatrix#identities ScranMatrix.identities}.
  *
- * @return {ScranMatrix} A layered sparse matrix.
+ * @return {ScranMatrix} 
+ * If `layered = false`, a sparse matrix is returned with no reorganization of the rows.
+ *
+ * If `layered = true`, a layered sparse matrix is returned where rows are shuffled to enable use of smaller integer types for low-abundance genes.
  */
-export function initializeSparseMatrixFromHDF5(file, name) {
+export function initializeSparseMatrixFromHDF5(file, name, { layered = true } = {}) {
     return gc.call(
-        module => module.read_hdf5_matrix(file, name),
+        module => module.read_hdf5_matrix(file, name, layered),
         ScranMatrix
     );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "scran.js",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Single cell RNA-seq analysis in Javascript",
     "license": "MIT",
     "main": "main/index.js",

--- a/src/NumericMatrix.cpp
+++ b/src/NumericMatrix.cpp
@@ -2,6 +2,8 @@
 #include "NumericMatrix.h"
 #include "JSVector.h"
 
+NumericMatrix::NumericMatrix() {}
+
 NumericMatrix::NumericMatrix(const tatami::NumericMatrix* p) : ptr(std::shared_ptr<const tatami::NumericMatrix>(p)), is_reorganized(false) {}
 
 NumericMatrix::NumericMatrix(std::shared_ptr<const tatami::NumericMatrix> p) : ptr(std::move(p)), is_reorganized(false) {}

--- a/src/NumericMatrix.h
+++ b/src/NumericMatrix.h
@@ -15,6 +15,8 @@
  * @brief Javascript-visible interface for a matrix of `double`s.
  */
 struct NumericMatrix {
+    NumericMatrix();
+
     /** Construct a `NumericMatrix` from an existing pointer to a `tatami::NumericMatrix`.
      *
      * @param p Pointer to a `tatami::NumericMatrix`.

--- a/src/read_hdf5_matrix.cpp
+++ b/src/read_hdf5_matrix.cpp
@@ -9,7 +9,7 @@
 #include "tatami/ext/HDF5CompressedSparseMatrix.hpp"
 #include "tatami/ext/convert_to_layered_sparse.hpp"
 
-NumericMatrix read_hdf5_matrix(std::string path, std::string name) {
+NumericMatrix read_hdf5_matrix(std::string path, std::string name, bool layered) {
     bool is_dense;
     bool csc = true;
     size_t nr, nc;
@@ -88,16 +88,30 @@ NumericMatrix read_hdf5_matrix(std::string path, std::string name) {
     // need a large number of small reads to maintain memory usage below its
     // limit across all threads). So we just disable it.
     enable_parallel = false;
-    tatami::LayeredMatrixData<double, int> output;
-    try {
-        output = tatami::convert_to_layered_sparse<double, int>(mat.get()); 
-    } catch (std::exception& e) {
-        enable_parallel = true;
-        throw e;
-    }
-    enable_parallel = true;
 
-    return NumericMatrix(std::move(output.matrix), permutation_to_indices(output.permutation));
+    if (layered) {
+        tatami::LayeredMatrixData<double, int> output;
+        try {
+            output = tatami::convert_to_layered_sparse<double, int>(mat.get()); 
+        } catch (std::exception& e) {
+            enable_parallel = true;
+            throw e;
+        }
+        enable_parallel = true;
+        return NumericMatrix(std::move(output.matrix), permutation_to_indices(output.permutation));
+    } else {
+        std::shared_ptr<tatami::Matrix<double, int> > output;
+        try {
+            // TODO: add a template parameter to avoid the double conversion here.
+            // The storage type need not be the same as the interface type.
+            output = tatami::convert_to_sparse<false, tatami::Matrix<int, int>, double, int>(mat.get()); 
+        } catch (std::exception& e) {
+            enable_parallel = true;
+            throw e;
+        }
+        enable_parallel = true;
+        return NumericMatrix(std::move(output));
+    }
 }
 
 /**

--- a/src/read_matrix_market.cpp
+++ b/src/read_matrix_market.cpp
@@ -1,7 +1,7 @@
 #include <emscripten.h>
 #include <emscripten/bind.h>
 
-#include "utils.h"
+#include "read_utils.h"
 #include "NumericMatrix.h"
 #include <cstdint>
 

--- a/src/read_matrix_market.cpp
+++ b/src/read_matrix_market.cpp
@@ -7,15 +7,26 @@
 
 #include "tatami/ext/MatrixMarket_layered.hpp"
 
-NumericMatrix read_matrix_market_from_buffer(uintptr_t buffer, int size, int compressed) {
+NumericMatrix read_matrix_market_from_buffer(uintptr_t buffer, int size, int compressed, bool layered) {
     unsigned char* bufptr = reinterpret_cast<unsigned char*>(buffer);
-    auto stuff = tatami::MatrixMarket::load_layered_sparse_matrix_from_buffer(bufptr, size, compressed);
-    return NumericMatrix(std::move(stuff.matrix), permutation_to_indices(stuff.permutation));
+
+    if (layered) {
+        auto stuff = tatami::MatrixMarket::load_layered_sparse_matrix_from_buffer(bufptr, size, compressed);
+        return NumericMatrix(std::move(stuff.matrix), permutation_to_indices(stuff.permutation));
+    } else {
+        auto stuff = tatami::MatrixMarket::load_sparse_matrix_from_buffer(bufptr, size, compressed);
+        return NumericMatrix(std::move(stuff));
+    }
 }
 
-NumericMatrix read_matrix_market_from_file(std::string path, int compressed) {
-    auto stuff = tatami::MatrixMarket::load_layered_sparse_matrix_from_file(path.c_str(), compressed);
-    return NumericMatrix(std::move(stuff.matrix), permutation_to_indices(stuff.permutation));
+NumericMatrix read_matrix_market_from_file(std::string path, int compressed, bool layered) {
+    if (layered) {
+        auto stuff = tatami::MatrixMarket::load_layered_sparse_matrix_from_file(path.c_str(), compressed);
+        return NumericMatrix(std::move(stuff.matrix), permutation_to_indices(stuff.permutation));
+    } else {
+        auto stuff = tatami::MatrixMarket::load_sparse_matrix_from_file(path.c_str(), compressed);
+        return NumericMatrix(std::move(stuff));
+    }
 }
 
 void read_matrix_market_header_from_buffer(uintptr_t buffer, int size, int compressed, uintptr_t output) {

--- a/src/read_utils.h
+++ b/src/read_utils.h
@@ -1,0 +1,29 @@
+#ifndef INIT_UTILS_HPP
+#define INIT_UTILS_HPP
+
+#include "NumericMatrix.h"
+#include "tatami/tatami.hpp"
+#include "tatami/ext/convert_to_layered_sparse.hpp"
+
+inline std::vector<size_t> permutation_to_indices(const std::vector<size_t>& permutation) { 
+    std::vector<size_t> ids(permutation.size());
+    for (size_t i = 0; i < ids.size(); ++i) {
+        ids[permutation[i]] = i;
+    }
+    return ids;
+}
+
+template<class Matrix>
+NumericMatrix sparse_from_tatami(const Matrix* mat, bool layered) {
+    if (layered) {
+        auto output = tatami::convert_to_layered_sparse(mat); 
+        return NumericMatrix(std::move(output.matrix), permutation_to_indices(output.permutation));
+    } else {
+        // TODO: add a template parameter to avoid the double conversion here.
+        // The storage type need not be the same as the interface type.
+        auto output = tatami::convert_to_sparse<false, Matrix, double, int>(mat); 
+        return NumericMatrix(std::move(output));
+    }
+}
+
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -17,12 +17,4 @@ std::vector<T> convert_array_of_offsets(size_t n, uintptr_t x) {
     return output;
 }
 
-inline std::vector<size_t> permutation_to_indices(const std::vector<size_t>& permutation) { 
-    std::vector<size_t> ids(permutation.size());
-    for (size_t i = 0; i < ids.size(); ++i) {
-        ids[permutation[i]] = i;
-    }
-    return ids;
-}
-
 #endif

--- a/tests/compare.js
+++ b/tests/compare.js
@@ -25,3 +25,12 @@ export function equalFloatArrays(x, y, tol = 0.00001) {
 
     return true;
 }
+
+export function areIndicesConsecutive(x, start = 0) {
+    for (var i = 0; i < x.length; i++) {
+        if (x[i] != start + i) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/tests/initializeSparseMatrix.test.js
+++ b/tests/initializeSparseMatrix.test.js
@@ -2,6 +2,7 @@ import * as scran from "../js/index.js";
 import * as compare from "./compare.js";
 import * as pako from "pako";
 import * as fs from "fs";
+import * as simulate from "./simulate.js";
 
 const dir = "MatrixMarket-test-files";
 if (!fs.existsSync(dir)) {
@@ -111,34 +112,76 @@ test("initialization from compressed values works with reorganization", () => {
     mat.free();
 })
 
-test("initialization from MatrixMarket works correctly", () => {
-    var content = "%%\n11 5 6\n1 2 5\n10 3 2\n7 4 22\n5 1 12\n6 3 2\n1 5 8\n";
+function convertToMatrixMarket(nr, nc, data, indices, indptrs) {
+    let triplets = [];
+    for (var i = 0; i < nc; i++) {
+        for (var j = indptrs[i]; j < indptrs[i+1]; j++) {
+            triplets.push({ value: String(indices[j] + 1) + " " + String(i + 1) + " " + String(data[j]), order: Math.random() })
+        }
+    }
+    triplets.sort((a, b) => a.order - b.order)
+    let header = "%%\n" + String(nr) + " " + String(nc) + " " + String(data.length) + "\n";
+    return header + triplets.map(x => x.value).join("\n")
+}
+
+test("simple initialization from MatrixMarket works correctly", () => {
+    // Creating a CSC sparse matrix, spiking in big numbers every even row.
+    let nr = 49;
+    let nc = 23;
+    const { data, indices, indptrs } = simulate.simulateSparseData(nc, nr, /* injectBigValues = */ true);
+
+    const content = convertToMatrixMarket(nr, nc, data, indices, indptrs);
     const converter = new TextEncoder();
     var raw_buffer = converter.encode(content);
-
     var buffer = scran.createUint8WasmArray(raw_buffer.length);
     buffer.set(raw_buffer);
 
-    var mat = scran.initializeSparseMatrixFromMatrixMarket(buffer);
-    expect(mat.numberOfRows()).toBe(11);
-    expect(mat.numberOfColumns()).toBe(5);
-    expect(mat.isReorganized()).toBe(true);
-
-    expect(compare.equalArrays(mat.row(0), [0, 5, 0, 0, 8])).toBe(true);
-    expect(compare.equalArrays(mat.column(4), [8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])).toBe(true);
+    var mat = scran.initializeSparseMatrixFromMatrixMarket(buffer, { layered: false });
+    expect(mat.numberOfRows()).toBe(nr);
+    expect(mat.numberOfColumns()).toBe(nc);
+    expect(mat.isReorganized()).toBe(false);
 
     // Also works if we dump it into a file.
     const path = dir + "/test.mtx";
     fs.writeFileSync(path, content);
-    var mat2 = scran.initializeSparseMatrixFromMatrixMarket(path);
+    var mat2 = scran.initializeSparseMatrixFromMatrixMarket(path, { layered: false });
 
-    expect(mat2.numberOfRows()).toBe(11);
-    expect(mat2.numberOfColumns()).toBe(5);
-    expect(compare.equalArrays(mat2.row(5), mat.row(5))).toBe(true);
+    expect(mat2.numberOfRows()).toBe(nr);
+    expect(mat2.numberOfColumns()).toBe(nc);
+    expect(mat2.isReorganized()).toBe(false);
+
+    // Works with layered matrices.
+    var lmat = scran.initializeSparseMatrixFromMatrixMarket(buffer);
+    expect(lmat.isReorganized()).toBe(true);
+    var lmat2 = scran.initializeSparseMatrixFromMatrixMarket(path);
+    expect(lmat2.isReorganized()).toBe(true);
+    let ids = lmat.identities();
+
+    expect(compare.equalArrays(ids, lmat2.identities())).toBe(true);
+    expect(compare.areIndicesConsecutive(ids)).toBe(false);
+    expect(compare.areIndicesConsecutive(ids.slice().sort())).toBe(true);
+
+    // Same results compared to naive iteration.
+    for (var c = 0; c < nc; c++) {
+        let ref = new Array(nr);
+        ref.fill(0);
+        for (var j = indptrs[c]; j < indptrs[c+1]; j++) {
+            ref[indices[j]] = data[j];
+        }
+        expect(compare.equalArrays(mat.column(c), ref)).toBe(true);
+        expect(compare.equalArrays(mat2.column(c), ref)).toBe(true);
+
+        let lref = new Array(nr);
+        ids.forEach((x, i) => {
+            lref[i] = ref[x];
+        });
+        expect(compare.equalArrays(lmat.column(c), lref)).toBe(true);
+        expect(compare.equalArrays(lmat2.column(c), lref)).toBe(true);
+    }
 
     // Inspection of dimensions works correctly.
     let deets = scran.extractMatrixMarketDimensions(path);
-    expect(deets).toEqual({ rows: 11, columns: 5, lines: 6 });
+    expect(deets).toEqual({ rows: nr, columns: nc, lines: data.length });
     let deets2 = scran.extractMatrixMarketDimensions(buffer);
     expect(deets).toEqual(deets2);
  

--- a/tests/simulate.js
+++ b/tests/simulate.js
@@ -1,5 +1,50 @@
 import * as scran from "../js/index.js";
 
+export function simulateSparseData(primary, secondary, injectBigValues = false) {
+    let data = [];
+    let indices = [];
+    let indptrs = new Uint32Array(primary + 1);
+    indptrs[0] = 0;
+
+    for (var i = 0; i < primary; i++) {
+        indptrs[i+1] = indptrs[i];
+
+        for (var j = 0; j < secondary; j++) {
+            if (Math.random() < 0.05) { // 5% density
+                indices.push(j);
+                indptrs[i+1]++;
+
+                let candidate = Math.random() * 100; // i.e., in (0, 100)
+                if (injectBigValues) {
+                    if (j % 2 == 0) {
+                        candidate *= 10;
+                        candidate += 1000; // i.e., in (1000, 2000)
+                    } else if (j % 4 == 0) {
+                        candidate *= 1000;
+                        candidate += 100000; // i.e., in (100000, 200000)
+                    }
+                }
+
+                data.push(candidate);
+            }
+        }
+    }
+
+    let data2 = new Uint16Array(data.length);
+    data2.set(data);
+    let indices2 = new Int32Array(indices.length);
+    indices2.set(indices);
+    let indptrs2 = new Uint32Array(indptrs.length);
+    indptrs2.set(indptrs);
+
+    return {
+        "data": data2,
+        "indices": indices2,
+        "indptrs": indptrs2
+    };
+}
+
+
 export function simulateMatrix(numberOfRows, numberOfColumns, density = 0.2, maxValue = 10) {
     var buffer = scran.createInt32WasmArray(numberOfRows * numberOfColumns);
     let output;


### PR DESCRIPTION
Users can sacrifice memory efficiency if they don't want to deal with the
hassle of row reorganization. Note that this is still a little less efficient
than it could be because currently the coercion to CSC matrices does not allow
a distinction between the storage (int, ideally) and interface type (double).